### PR TITLE
Updating description to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ We use Maven to compile it. See below for a step-by-step tutorial.
 </repository>
 ```
 
-2. Place this to your dependencies:
+2. Place this to your dependencies (Replace `{COMMIT}` with the latest [commit-hash]):
 
 ```xml
 <dependency>
 	<groupId>com.github.kangarko</groupId>
 	<artifactId>CompatBridge</artifactId>
-	<version>2.0.0</version> <!-- change to the latest version -->
+	<version>{COMMIT}</version> <!-- change to the latest version -->
 	<scope>compile</scope>
 </dependency>
 ```
@@ -72,3 +72,5 @@ IF YOU ALREADY HAVE A SHADE PLUGIN, ONLY USE THE RELOCATION SECTION FROM BELOW.
 ```
 
 Copyright (C) 2019. All Rights Reserved. Commercial and non-commercial use allowed as long as you provide a clear reference for the original author.  
+
+[commit-hash]: https://github.com/kangarko/CompatBridge/commits/master

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We use Maven to compile it. See below for a step-by-step tutorial.
 <dependency>
 	<groupId>com.github.kangarko</groupId>
 	<artifactId>CompatBridge</artifactId>
-	<version>{COMMIT}</version> <!-- change to the latest version -->
+	<version>{COMMIT}</version>
 	<scope>compile</scope>
 </dependency>
 ```


### PR DESCRIPTION
[39f5a8e]: https://github.com/kangarko/CompatBridge/commit/39f5a8ee12dc6a42c3a949a26b0b64bc55d74d53

The description of the readme is misleading, since it tells you to directly put f.e.  `2.0.0` as the version into your project.
This is not how jitpack works, since it requires you to make releases here.
However. There is the alternative of using the short github-hash (like f.e. [39f5a8e]) in the version to download a specific version of this repository.

This PR clears the description of the README to prevent future confusion about this thing,